### PR TITLE
add: conftest on dockerfile

### DIFF
--- a/.github/workflows/conftest.yml
+++ b/.github/workflows/conftest.yml
@@ -1,0 +1,11 @@
+on: push
+name: Conftest
+jobs:
+  conftest:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: test
+      uses: instrumenta/conftest-action@master
+      with:
+        files: tracking_server/tracking.Dockerfile

--- a/policy/dockerfile_security.rego
+++ b/policy/dockerfile_security.rego
@@ -1,0 +1,88 @@
+# GNU Lesser General Public License v3.0 only
+# Copyright (C) 2020 Artefact
+# licence-information@artefact.com
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+package main
+
+suspicious_env_keys = [
+    "passwd",
+    "password",
+    "pwd",
+    "secret",
+    "key",
+    "access",
+    "api_key",
+    "apikey",
+    "token",
+]
+
+pkg_update_commands = [
+    "apk upgrade",
+    "apt-get upgrade",
+    "dist-upgrade",
+]
+
+image_tag_list = [
+    "latest",
+    "LATEST",
+]
+
+# Looking for suspicious environemnt variables
+deny[msg] {    
+    input[i].Cmd == "env"
+    val := input[i].Value
+    contains(lower(val[_]), suspicious_env_keys[_])
+    msg = sprintf("Suspicious ENV key found: %s", [val])
+}
+
+# Looking for latest docker image used
+deny[msg] {
+    input[i].Cmd == "from"
+    val := split(input[i].Value[0], ":")
+    count(val) == 1
+    msg = sprintf("Do not use latest tag with image: %s", [val])
+}
+
+# Looking for latest docker image used
+deny[msg] {
+    input[i].Cmd == "from"
+    val := split(input[i].Value[0], ":")
+    contains(val[1], image_tag_list[_])
+    msg = sprintf("Do not use latest tag with image: %s", [input[i].Value])
+}
+
+# Looking for apk upgrade command used in Dockerfile
+deny[msg] {
+    input[i].Cmd == "run"
+    val := concat(" ", input[i].Value)
+    contains(val, pkg_update_commands[_])
+    msg = sprintf("Do not use upgrade commands: %s", [val])
+}
+
+# Looking for ADD command instead using COPY command
+deny[msg] {
+    input[i].Cmd == "add"
+    val := concat(" ", input[i].Value)
+    msg = sprintf("Use COPY instead of ADD: %s", [val])
+}
+
+# sudo usage
+deny[msg] {
+    input[i].Cmd == "run"
+    val := concat(" ", input[i].Value)
+    contains(lower(val), "sudo")
+    msg = sprintf("Avoid using 'sudo' command: %s", [val])
+}


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following Issue #37 

### Description

- [x] Add conftest in CI to test Dockerfile. Conftest policy taken from https://github.com/madhuakula/docker-security-checker/blob/master/policy/security.rego

### Licence

- [x] My PR adds the needed licence header to every added file:

### Commits

- [x] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  2. Subject is limited to 50 characters
  3. Subject does not end with a period
  4. Subject uses the imperative mood ("add", not "adding")
  5. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does