### PR TITLE
Hofix/pip version

### DIFF
--- a/tracking_server/tracking.Dockerfile
+++ b/tracking_server/tracking.Dockerfile
@@ -29,6 +29,7 @@ ENV PATH $PATH:/root/google-cloud-sdk/bin
 RUN gcloud components install beta -q
 
 COPY requirements.txt .
+RUN python -m pip install pip==21.0.1
 RUN pip install -r requirements.txt
 
 COPY run_tracking.sh .


### PR DESCRIPTION
### Issue

Could not build wheels for cryptography which use PEP 517


### Description

Upgrade pip and fix it to latest version
