### PR TITLE
Av/feat/various

### DIFF
--- a/IaC/main.tf
+++ b/IaC/main.tf
@@ -43,6 +43,7 @@ module "network" {
 
 module "mlflow" {
   source                       = "./modules/mlflow"
+  mlflow_server                = var.mlflow_server
   artifacts_bucket_name        = "${var.artifacts_bucket}-${random_id.artifacts_bucket_name_suffix.hex}"
   db_password_value            = var.db_password_value
   server_docker_image          = var.mlflow_docker_image
@@ -51,7 +52,7 @@ module "mlflow" {
   web_app_users                = var.web_app_users
   network_self_link            = module.network.network_self_link
   network_short_name           = module.network.network_short_name
-  mlflow_server                = var.nb_app_engine_services != 0 ? var.mlflow_server : "default"
+  create_default_service       = var.create_default_service == 1 ? true : false
   oauth_client_id              = var.oauth_client_id
   oauth_client_secret          = var.oauth_client_secret
 }

--- a/IaC/main.tf
+++ b/IaC/main.tf
@@ -55,6 +55,8 @@ module "mlflow" {
   create_default_service       = var.create_default_service == 1 ? true : false
   oauth_client_id              = var.oauth_client_id
   oauth_client_secret          = var.oauth_client_secret
+  brand_exists                 = var.brand_exists
+  brand_name                   = var.brand_name
 }
 
 module "log_pusher" {

--- a/IaC/modules/mlflow/artifacts/main.tf
+++ b/IaC/modules/mlflow/artifacts/main.tf
@@ -31,4 +31,5 @@ resource "google_storage_bucket" "this" {
     }
   }
   uniform_bucket_level_access = var.storage_uniform
+  force_destroy = true
 }

--- a/IaC/modules/mlflow/artifacts/main.tf
+++ b/IaC/modules/mlflow/artifacts/main.tf
@@ -31,5 +31,5 @@ resource "google_storage_bucket" "this" {
     }
   }
   uniform_bucket_level_access = var.storage_uniform
-  force_destroy = true
+  force_destroy               = true
 }

--- a/IaC/modules/mlflow/main.tf
+++ b/IaC/modules/mlflow/main.tf
@@ -44,7 +44,8 @@ module "database" {
 
 module "server" {
   source                       = "./server"
-  service                      = var.mlflow_server
+  mlflow_server                = var.mlflow_server
+  create_default_service       = var.create_default_service
   location                     = var.server_location
   docker_image_name            = var.server_docker_image
   env_variables                = var.server_env_variables

--- a/IaC/modules/mlflow/main.tf
+++ b/IaC/modules/mlflow/main.tf
@@ -62,4 +62,6 @@ module "server" {
   network_short_name           = var.network_short_name
   oauth_client_id              = var.oauth_client_id
   oauth_client_secret          = var.oauth_client_secret
+  brand_exists                 = var.brand_exists
+  brand_name                   = var.brand_name
 }

--- a/IaC/modules/mlflow/server/main.tf
+++ b/IaC/modules/mlflow/server/main.tf
@@ -74,8 +74,43 @@ resource "google_project_iam_member" "gae_api" {
   member     = format("serviceAccount:%s@appspot.gserviceaccount.com", data.google_project.project.project_id)
 }
 
-resource "google_app_engine_flexible_app_version" "myapp_v1" {
-  service    = var.service
+resource "google_app_engine_flexible_app_version" "default_app" {
+  count = var.create_default_service ? 1 : 0
+  service = "default"
+  version_id = "mlflow-default"
+  runtime    = "custom"
+
+  deployment {
+    container {
+      image = "gcr.io/cloudrun/hello"
+    }
+  }
+
+  liveness_check {
+    path = "/"
+  }
+
+  readiness_check {
+    path = "/"
+  }
+
+  automatic_scaling {
+    cool_down_period = "120s"
+    min_total_instances = 1
+    max_total_instances = 1
+    cpu_utilization {
+      target_utilization = 0.5
+    }
+  }
+
+  delete_service_on_destroy = false
+  noop_on_destroy = true
+
+  depends_on      = [google_app_engine_application.app]
+}
+
+resource "google_app_engine_flexible_app_version" "mlflow_app" {
+  service    = var.mlflow_server
   version_id = "v0"
   runtime    = "custom"
 
@@ -116,13 +151,20 @@ resource "google_app_engine_flexible_app_version" "myapp_v1" {
     cloud_sql_instances = format("%s=tcp:3306", var.db_instance)
   }
 
-  delete_service_on_destroy = var.service == "default" ? false : true
-  noop_on_destroy = var.service == "default" ? true : false
+  delete_service_on_destroy = true
+  noop_on_destroy = false
 
   timeouts {
     create = "20m"
   }
-  depends_on      = [google_project_iam_member.gcs, google_project_iam_member.gae_gcs, google_project_iam_member.cloudsql, google_project_iam_member.secret, google_project_iam_member.gae_api]
+  depends_on      = [
+    google_app_engine_flexible_app_version.default_app,
+    google_project_iam_member.gcs,
+    google_project_iam_member.gae_gcs,
+    google_project_iam_member.cloudsql,
+    google_project_iam_member.secret,
+    google_project_iam_member.gae_api
+  ]
 }
 
 resource "google_iap_brand" "project_brand" {
@@ -136,10 +178,12 @@ resource "google_iap_client" "project_client" {
   display_name = "mlflow"
   brand        = google_iap_brand.project_brand[0].name
 }
-resource "google_iap_app_engine_service_iam_binding" "member" {
-  project = data.google_project.project.project_id
-  app_id  = data.google_project.project.project_id
-  service = google_app_engine_flexible_app_version.myapp_v1.service
-  role    = "roles/iap.httpsResourceAccessor"
-  members = var.web_app_users
+
+resource "google_iap_app_engine_service_iam_member" "member" {
+  for_each = toset(var.web_app_users)
+  project  = data.google_project.project.project_id
+  app_id   = data.google_project.project.project_id
+  service  = google_app_engine_flexible_app_version.mlflow_app.service
+  role     = "roles/iap.httpsResourceAccessor"
+  member   = each.key
 }

--- a/IaC/modules/mlflow/server/main.tf
+++ b/IaC/modules/mlflow/server/main.tf
@@ -168,7 +168,7 @@ resource "google_app_engine_flexible_app_version" "mlflow_app" {
 }
 
 resource "google_iap_brand" "project_brand" {
-  count             = var.consent_screen_support_email == "" ? 0 : 1
+  count             = var.brand_exists == 1 ? 0 : 1
   support_email     = var.consent_screen_support_email
   application_title = "mlflow"
   project           = data.google_project.project.number
@@ -176,7 +176,7 @@ resource "google_iap_brand" "project_brand" {
 resource "google_iap_client" "project_client" {
   count        = var.consent_screen_support_email == "" ? 0 : 1
   display_name = "mlflow"
-  brand        = google_iap_brand.project_brand[0].name
+  brand        = var.brand_exists == 1 ? var.brand_name : google_iap_brand.project_brand[0].name
 }
 
 resource "google_iap_app_engine_service_iam_member" "member" {

--- a/IaC/modules/mlflow/server/main.tf
+++ b/IaC/modules/mlflow/server/main.tf
@@ -75,8 +75,8 @@ resource "google_project_iam_member" "gae_api" {
 }
 
 resource "google_app_engine_flexible_app_version" "default_app" {
-  count = var.create_default_service ? 1 : 0
-  service = "default"
+  count      = var.create_default_service ? 1 : 0
+  service    = "default"
   version_id = "mlflow-default"
   runtime    = "custom"
 
@@ -95,7 +95,7 @@ resource "google_app_engine_flexible_app_version" "default_app" {
   }
 
   automatic_scaling {
-    cool_down_period = "120s"
+    cool_down_period    = "120s"
     min_total_instances = 1
     max_total_instances = 1
     cpu_utilization {
@@ -104,9 +104,9 @@ resource "google_app_engine_flexible_app_version" "default_app" {
   }
 
   delete_service_on_destroy = false
-  noop_on_destroy = true
+  noop_on_destroy           = true
 
-  depends_on      = [google_app_engine_application.app]
+  depends_on = [google_app_engine_application.app]
 }
 
 resource "google_app_engine_flexible_app_version" "mlflow_app" {
@@ -152,12 +152,12 @@ resource "google_app_engine_flexible_app_version" "mlflow_app" {
   }
 
   delete_service_on_destroy = true
-  noop_on_destroy = false
+  noop_on_destroy           = false
 
   timeouts {
     create = "20m"
   }
-  depends_on      = [
+  depends_on = [
     google_app_engine_flexible_app_version.default_app,
     google_project_iam_member.gcs,
     google_project_iam_member.gae_gcs,
@@ -168,13 +168,13 @@ resource "google_app_engine_flexible_app_version" "mlflow_app" {
 }
 
 resource "google_iap_brand" "project_brand" {
-  count = var.consent_screen_support_email == "" ? 0 : 1
+  count             = var.consent_screen_support_email == "" ? 0 : 1
   support_email     = var.consent_screen_support_email
   application_title = "mlflow"
   project           = data.google_project.project.number
 }
 resource "google_iap_client" "project_client" {
-  count = var.consent_screen_support_email == "" ? 0 : 1
+  count        = var.consent_screen_support_email == "" ? 0 : 1
   display_name = "mlflow"
   brand        = google_iap_brand.project_brand[0].name
 }

--- a/IaC/modules/mlflow/server/main.tf
+++ b/IaC/modules/mlflow/server/main.tf
@@ -34,8 +34,8 @@ resource "google_app_engine_application" "app" {
   location_id = var.location
   iap {
     enabled              = true
-    oauth2_client_id     = var.oauth_client_id != "" ? var.oauth_client_id : google_iap_client.project_client[0].client_id
-    oauth2_client_secret = var.oauth_client_secret != "" ? var.oauth_client_secret : google_iap_client.project_client[0].secret
+    oauth2_client_id     = var.oauth_client_id == "" ? google_iap_client.project_client[0].client_id : var.oauth_client_id
+    oauth2_client_secret = var.oauth_client_secret == "" ? google_iap_client.project_client[0].secret : var.oauth_client_secret
   }
 }
 
@@ -173,8 +173,9 @@ resource "google_iap_brand" "project_brand" {
   application_title = "mlflow"
   project           = data.google_project.project.number
 }
+
 resource "google_iap_client" "project_client" {
-  count        = var.consent_screen_support_email == "" ? 0 : 1
+  count        = var.oauth_client_id == "" ? 1 : 0
   display_name = "mlflow"
   brand        = var.brand_exists == 1 ? var.brand_name : google_iap_brand.project_brand[0].name
 }

--- a/IaC/modules/mlflow/server/variables.tf
+++ b/IaC/modules/mlflow/server/variables.tf
@@ -25,7 +25,7 @@ variable "docker_image_name" {
   description = "Name of the docker image"
 }
 variable "env_variables" {
-  type        = map
+  type        = map(any)
   description = "Env variable to be used in your container"
 }
 variable "project_id" {
@@ -70,7 +70,7 @@ variable "web_app_users" {
 }
 variable "create_default_service" {
   description = "Whether or not to create a default app engine service"
-  type = bool
+  type        = bool
 }
 variable "mlflow_server" {
   description = "Name of the mlflow server deployed to app engine. If a service already have this name, it will be overwritten."

--- a/IaC/modules/mlflow/server/variables.tf
+++ b/IaC/modules/mlflow/server/variables.tf
@@ -64,6 +64,14 @@ variable "consent_screen_support_email" {
   type        = string
   description = "Person or group to contact in case of problem"
 }
+variable "brand_exists" {
+  type        = number
+  description = "1 if the brand exists 0 otherwise"
+}
+variable "brand_name" {
+  type        = string
+  description = "Name of the brand if it exists"
+}
 variable "web_app_users" {
   type        = list(string)
   description = "List of people who can acess the mlflow web app. e.g. [user:jane@example.com, group:people@example.com]"

--- a/IaC/modules/mlflow/server/variables.tf
+++ b/IaC/modules/mlflow/server/variables.tf
@@ -68,9 +68,13 @@ variable "web_app_users" {
   type        = list(string)
   description = "List of people who can acess the mlflow web app. e.g. [user:jane@example.com, group:people@example.com]"
 }
-variable "service" {
-  description = "Name of the app engine service"
-  type = string
+variable "create_default_service" {
+  description = "Whether or not to create a default app engine service"
+  type = bool
+}
+variable "mlflow_server" {
+  description = "Name of the mlflow server deployed to app engine. If a service already have this name, it will be overwritten."
+  type        = string
 }
 variable "network_short_name" {
   type = string

--- a/IaC/modules/mlflow/variables.tf
+++ b/IaC/modules/mlflow/variables.tf
@@ -78,8 +78,12 @@ variable "db_name" {
   type        = string
   default     = "mlflow"
 }
+variable "create_default_service" {
+  description = "Whether or not to create a default app engine service"
+  type = bool
+}
 variable "mlflow_server" {
-  description = "Name of the mlflow server deployed to app engine."
+  description = "Name of the mlflow server deployed to app engine. If a service already have this name, it will be overwritten."
   type        = string
 }
 variable "server_location" {

--- a/IaC/modules/mlflow/variables.tf
+++ b/IaC/modules/mlflow/variables.tf
@@ -128,3 +128,11 @@ variable "oauth_client_secret" {
   type        = string
   description = "Oauth client secret, empty if consent screen not set up"
 }
+variable "brand_exists" {
+  type        = number
+  description = "1 if the brand exists 0 otherwise"
+}
+variable "brand_name" {
+  type        = string
+  description = "Name of the brand if it exists"
+}

--- a/IaC/modules/mlflow/variables.tf
+++ b/IaC/modules/mlflow/variables.tf
@@ -80,7 +80,7 @@ variable "db_name" {
 }
 variable "create_default_service" {
   description = "Whether or not to create a default app engine service"
-  type = bool
+  type        = bool
 }
 variable "mlflow_server" {
   description = "Name of the mlflow server deployed to app engine. If a service already have this name, it will be overwritten."
@@ -97,7 +97,7 @@ variable "server_docker_image" {
 }
 variable "server_env_variables" {
   description = "Env variables used inside your container"
-  type        = map
+  type        = map(any)
   default     = {}
 }
 variable "project_id" {

--- a/IaC/variables.tf
+++ b/IaC/variables.tf
@@ -66,3 +66,12 @@ variable "oauth_client_secret" {
   type        = string
   description = "Oauth client secret, empty if consent screen not set up"
 }
+variable "brand_exists" {
+  type        = number
+  description = "1 if the brand exists 0 otherwise"
+}
+variable "brand_name" {
+  type        = string
+  default     = ""
+  description = "Name of the brand if it exists"
+}

--- a/IaC/variables.tf
+++ b/IaC/variables.tf
@@ -54,8 +54,8 @@ variable "mlflow_server" {
   type        = string
   default     = "mlflow"
 }
-variable "nb_app_engine_services" {
-  description = "Number of app engine services deployed. If 0, server name will be default"
+variable "create_default_service" {
+  description = "Whether or not to deploy a default AppEngine App"
   type        = number
 }
 variable "oauth_client_id" {

--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,18 @@ plan-terraform:
 import-terraform:
 	source vars_base && cd Iac && ./../bin/terraform_import.sh
 
+gae-check:
+	source vars_base && cd Iac && ./../bin/app_engine_check.sh
+
 destroy-terraform:
 	source vars_base && cd Iac && terraform destroy
 
-apply: init-terraform import-terraform apply-terraform
-apply-cicd: init-terraform import-terraform apply-terraform-cicd
+setup-new-project:
+	rm -rf .terraform vars_additionnal && cd Iac && rm -rf .terraform && rm -rf .terraform.lock.hcl && rm -rf prerequesites/.terraform && rm -rf prerequesites/.terraform.lock.hcl && rm -rf prerequesites/terraform.tfstate && rm -rf prerequesites/terraform.tfstate.backup
+	source vars && gcloud config set project $${TF_VAR_project_id} && gcloud auth login && gcloud auth application-default login
+
+apply: init-terraform import-terraform gae-check apply-terraform
+apply-cicd: init-terraform import-terraform gae-check apply-terraform-cicd
 
 plan: init-terraform plan-terraform
 

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ setup-new-project:
 	rm -rf .terraform vars_additionnal && cd Iac && rm -rf .terraform && rm -rf .terraform.lock.hcl && rm -rf prerequesites/.terraform && rm -rf prerequesites/.terraform.lock.hcl && rm -rf prerequesites/terraform.tfstate && rm -rf prerequesites/terraform.tfstate.backup
 	source vars && gcloud config set project $${TF_VAR_project_id} && gcloud auth login && gcloud auth application-default login
 
-apply: init-terraform import-terraform gae-check apply-terraform
-apply-cicd: init-terraform import-terraform gae-check apply-terraform-cicd
+apply: init-terraform gae-check import-terraform apply-terraform
+apply-cicd: init-terraform gae-check import-terraform apply-terraform-cicd
 
 plan: init-terraform plan-terraform
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,6 @@ Fill out the `vars` file.
 |`TF_VAR_web_app_users`|List of authorized users/groups/domains. Should be a single quoted list of string such as '["user:jane@example.com", "group:people@example.com", "domain:example.com"]'. Email addresses and domains must be associated with an active Google Account, G Suite account, or Cloud Identity account.|
 |`TF_VAR_network_name`|The network the application and backend should attach to. If left blank, a new network will be created. Hint: unless otherwise specified, a network named "default" will already exist on the project. To plug into this network, type TF_VAR_network_name=default into this variable.|
 |`TF_VAR_consent_screen_support_email`|Contact email address displayed by the SSO screen when the user trying to log in is not authorized. The address should be that of the user deploying mlflow (you) or a Cloud Identity group managed by this user. If you have already set-up your consent screen on the GCP project you can leave it blank|
-|`TF_VAR_oauth_client_id`|If the consent screen is already set up on your project, you need to fill this value with the IAP Oauth client id. Otherwise, leave it blank.|
-|`TF_VAR_oauth_client_secret`|If the consent screen is already set up on your project, you need to fill this value with the IAP Oauth client secret. Otherwise, leave it blank|
-
-You should either fill `TF_VAR_consent_screen_support_email` or (`TF_VAR_oauth_client_id` and `TF_VAR_oauth_client_secret`). Client id and client secret can be found on [Google Cloud Console](https://console.cloud.google.com/apis/credentials)
 
 **Run `make one-click-mlflow` and follow the prompts.**
 

--- a/bin/app_engine_check.sh
+++ b/bin/app_engine_check.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if gcloud app versions list 1> /dev/null 2> /dev/null ; then
+  DEPLOYED_VERSIONS=$(gcloud --format json app versions list | jq '.[] | select(.service=="default") | .id')
+else
+  DEPLOYED_VERSIONS=""
+fi
+
+if [[ "$DEPLOYED_VERSIONS" == *"mlflow-default"* ]] || [[ "$DEPLOYED_VERSIONS" == "" ]]; then
+  echo "A dummy app engine with the name default will be created"
+  echo export TF_VAR_create_default_service=1 >> ../vars_additionnal
+else
+  echo export TF_VAR_create_default_service=0 >> ../vars_additionnal
+fi

--- a/bin/terraform_import.sh
+++ b/bin/terraform_import.sh
@@ -13,14 +13,16 @@ fi
 
 
 if gcloud alpha iap oauth-brands list | grep "name: " 1> /dev/null 2> /dev/null; then
-  echo "A consent screen (brand) has already been configured on this project"
+  echo "A consent screen (brand) has already been configured on this project. It will be used as-is"
   export BRAND_EXISTS=1
+  echo export TF_VAR_brand_exists=1 >> ../vars_additionnal
   BRAND_NAME="projects/$TF_VAR_project_number/brands/$TF_VAR_project_number"
-  terraform import module.mlflow.module.server.google_iap_brand.project_brand $BRAND_NAME
+  echo export TF_VAR_brand_name=$BRAND_NAME >> ../vars_additionnal
 else
   echo "No consent screen (brand) has been configured on this project, a new one will be created"
   export BRAND_EXISTS=0
   echo "No oauth client exists on this project. A new one will be created"
+  echo export TF_VAR_brand_exists=0 >> ../vars_additionnal
   echo export TF_VAR_oauth_client_id="" >> ../vars_additionnal
   echo export TF_VAR_oauth_client_secret="" >> ../vars_additionnal
 fi

--- a/bin/terraform_import.sh
+++ b/bin/terraform_import.sh
@@ -10,3 +10,33 @@ if [ "$app_exists" == 1 ] && [ "$app_in_state" == 0 ]; then
     echo Importing app engine service
     terraform import module.mlflow.module.server.google_app_engine_application.app $TF_VAR_project_id
 fi
+
+
+if gcloud alpha iap oauth-brands list | grep "name: " 1> /dev/null 2> /dev/null; then
+  echo "A consent screen (brand) has already been configured on this project"
+  export BRAND_EXISTS=1
+  BRAND_NAME="projects/$TF_VAR_project_number/brands/$TF_VAR_project_number"
+  terraform import module.mlflow.module.server.google_iap_brand.project_brand $BRAND_NAME
+else
+  echo "No consent screen (brand) has been configured on this project, a new one will be created"
+  export BRAND_EXISTS=0
+  echo "No oauth client exists on this project. A new one will be created"
+  echo export TF_VAR_oauth_client_id="" >> ../vars_additionnal
+  echo export TF_VAR_oauth_client_secret="" >> ../vars_additionnal
+fi
+
+
+if [ $BRAND_EXISTS == 1 ]; then
+  CLIENT_DESCRIPTION=$(gcloud --format json alpha iap oauth-clients list "$BRAND_NAME")
+
+  if [ "$CLIENT_DESCRIPTION" != '[]' ]; then
+    echo "An oauth client has already been created on this project. It will be used for IAP access"
+    echo export TF_VAR_oauth_client_id=$(echo "$CLIENT_DESCRIPTION" | jq '.[0].name' | tr -d '"' | sed 's:.*/::') >> ../vars_additionnal
+    echo export TF_VAR_oauth_client_secret=$(echo "$CLIENT_DESCRIPTION" | jq '.[0].secret' | tr -d '"') >> ../vars_additionnal
+
+  else
+    echo "No oauth client exists on this project. A new one will be created"
+    echo export TF_VAR_oauth_client_id="" >> ../vars_additionnal
+    echo export TF_VAR_oauth_client_secret="" >> ../vars_additionnal
+  fi
+fi

--- a/examples/mlflow_config.py
+++ b/examples/mlflow_config.py
@@ -55,7 +55,7 @@ PROJECT_ID = input("Enter your project ID: ")
 EXPERIMENT_NAME = input("Enter the name of your MLFlow experiment: ")
 
 # If mlflow if not deployed on the default app engine service, change it with the url of your service <!-- omit in toc -->
-tracking_uri = f"https://{PROJECT_ID}.ew.r.appspot.com/"
+tracking_uri = f"https://mlflow-dot-{PROJECT_ID}.ew.r.appspot.com"
 
 os.environ["MLFLOW_TRACKING_TOKEN"] = get_token()
 

--- a/vars_base
+++ b/vars_base
@@ -1,9 +1,12 @@
 source vars
+touch vars_additionnal
+source vars_additionnal
+
+export TF_VAR_project_number=$(gcloud --format json projects describe $TF_VAR_project_id | jq '.["projectNumber"]' | tr -d '"')
 export DOCKER_REPO=eu.gcr.io
 export DOCKER_NAME=mlflow
 export DOCKER_TAG=0.1
 export TF_VAR_mlflow_docker_image=$DOCKER_REPO/$TF_VAR_project_id/$DOCKER_NAME:$DOCKER_TAG
-nb_app=$(gcloud --format json --project $TF_VAR_project_id app services list 2> /dev/null | jq length)
 export TF_VAR_nb_app_engine_services=${nb_app:-0}
 
 # app_exists will be true if the module.mlflow.server.google_app_engine_application.app resource exists


### PR DESCRIPTION
### Issue

resolves #51 

### Changes

- If no app engine service is deployed, a dummy default app will be deployed to occupy the `default` name and domain. This ensures that the URL of the MLFlow web server will always be `https://mlflow-dot-{PROJECT_ID}.ew.r.appspot.com`
- If a brand exists then it will be imported and used by one-click-mlflow. (Unsure if this is the behavior we want. Maybe we prefer to not touch the existing brand? Or give the user the possibility to choose?)
- If an oauth client already exists, use it instead of creating a new one.
- Replaced IAM bindings by members. This prevents loss of access for users on other services using IAP.
- Set force_destroy to true on buckets. This allows terraform to destroy the bucket + the data inside. Required if we want to properly test pushing artifacts then destroy the infra
- Added a makefile target to cleanup your local files when switching between dev projects.


### Testing

I validated this version by:
- deploying on a new project (make one-click-mlflow) + testing pushing experiments and seeing them in the UI
- deploying again to validate idempotency (make one-click-mlflow) + testing pushing experiments and seeing them in the UI
- destroyed (make destroy)
- deployed again to validate imports of brand/appengine app (make one-click-mlflow) + testing pushing experiments and seeing them in the UI

Sorry for the bulky PR with too many changes.