### PR TITLE
fix: password prompt deleted - shell makefile for linux users

### DIFF
--- a/IaC/main.tf
+++ b/IaC/main.tf
@@ -36,6 +36,10 @@ resource "random_id" "artifacts_bucket_name_suffix" {
   byte_length = 5
 }
 
+resource "random_password" "password" {
+  length = 16
+}
+
 module "network" {
   source = "./modules/network"
   network_name = var.network_name
@@ -44,7 +48,7 @@ module "network" {
 module "mlflow" {
   source = "./modules/mlflow"
   artifacts_bucket_name = "${var.artifacts_bucket}-${random_id.artifacts_bucket_name_suffix.hex}"
-  db_password_value = var.db_password_value
+  db_password_value = random_password.password.result
   server_docker_image = var.mlflow_docker_image
   project_id = var.project_id
   consent_screen_support_email = var.consent_screen_support_email

--- a/IaC/variables.tf
+++ b/IaC/variables.tf
@@ -24,10 +24,6 @@ variable "artifacts_bucket" {
     type = string
     default = "oneclick-mlflow-store"
 }
-variable "db_password_value" {
-    description = "Database password to connect to your instance"
-    type = string
-}
 variable "mlflow_docker_image" {
     description = "Docker image used in container registry"
     type = string

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
+ifeq ($(SHELL),/bin/sh)
+	SHELL:=/bin/bash
+endif
 pre-requesites:
-	source vars_base && cd Iac/prerequesites && terraform init && terraform apply
+	source vars_base && cd IaC/prerequesites && terraform init && terraform apply
 
 build-docker:
 	source vars_base && cd tracking_server && docker build -t $${TF_VAR_mlflow_docker_image} -f tracking.Dockerfile .
@@ -8,16 +11,16 @@ push-docker:
 	source vars_base && docker push $${TF_VAR_mlflow_docker_image}
 
 init-terraform:
-	source vars_base && cd Iac && terraform init -backend-config="bucket=$${TF_VAR_backend_bucket}"
+	source vars_base && cd IaC && terraform init -backend-config="bucket=$${TF_VAR_backend_bucket}"
 
 apply-terraform:
-	source vars_base && cd Iac && terraform apply
+	source vars_base && cd IaC && terraform apply
 
 plan-terraform:
-	source vars_base && cd Iac && terraform plan
+	source vars_base && cd IaC && terraform plan
 
 destroy-terraform:
-	source vars_base && cd Iac && terraform destroy
+	source vars_base && cd IaC && terraform destroy
 
 apply: init-terraform apply-terraform
 


### PR DESCRIPTION
### Issue
resolves #57 

### Description
- Removed the database password prompt by generating a random password. The password is treated as sensitive by default. (see https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password)
- Change from sh to bash the SHELL for GNU users. The default shell on GNU is sh and it does not include the command "source". 
 
###Tests
- I deployed the infra and checked if the changes were saved. 
- The changes within the makefile were just tested on GNU and it was ok. Maybe a deployment test on another OS is necessary. Will take care of this in the next few days. 