### PR TITLE
fix: no special char in db random password

### DIFF
--- a/IaC/modules/mlflow/secret_manager/main.tf
+++ b/IaC/modules/mlflow/secret_manager/main.tf
@@ -18,6 +18,7 @@
 
 resource "random_password" "password" {
   length = 16
+  special = false
 }
 
 resource "google_secret_manager_secret" "secret" {


### PR DESCRIPTION
### Issue

My PR resolves #69 

### Description

It removes special characters from the db random password as some of them could cause bugs