### PR TITLE
feat: CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,10 @@ destroy: init-terraform destroy-terraform
 #   TERRAFORM   #
 #################
 
+.PHONY: validate-terraform
+terraform:
+	@cd IaC & rm -rf .terraform & terraform init -backend=false & terraform validate
+
 .PHONY: init-terraform
 init-terraform:
 	@echo "Initializing Terraform..."

--- a/cloudbuild/e2e.yaml
+++ b/cloudbuild/e2e.yaml
@@ -3,7 +3,6 @@ steps:
   id: End-To-End test
   env:
     - 'PROJECT_ID=${_PROJECT_ID}'
-    - 'PROJECT_NUMBER=${_PROJECT_NUMBER}'
   entrypoint: 'bash'
   args:
     - -c
@@ -12,6 +11,6 @@ steps:
         CI_PROJECT_ID=ocmlf-github-ci-$(uuidgen)
         gcloud projects create $CI_PROJECT_ID --name=ocmlf-github-ci
         make validate-terraform && \
-        echo -e "${CI_PROJECT_ID}\1\4" | make one-click-mlflow && \
+        echo -e "${CI_PROJECT_ID}\1\\4\y" | make one-click-mlflow && \
         make destroy && \
         gcp projects delete $CI_PROJECT_ID

--- a/cloudbuild/e2e.yaml
+++ b/cloudbuild/e2e.yaml
@@ -1,0 +1,17 @@
+steps:
+- name: 'eu.gcr.io/${_PROJECT_ID}/ocmlf-builderterraformgcloud:1.0.0'
+  id: End-To-End test
+  env:
+    - 'PROJECT_ID=${_PROJECT_ID}'
+    - 'PROJECT_NUMBER=${_PROJECT_NUMBER}'
+  entrypoint: 'bash'
+  args:
+    - -c
+    - |
+        export GOOGLE_OAUTH_ACCESS_TOKEN=$(gcloud auth print-access-token --impersonate-service-account=ocmlf-ci-sa@${PROJECT_ID}.iam.gserviceaccount.com)
+        CI_PROJECT_ID=ocmlf-github-ci-$(uuidgen)
+        gcloud projects create $CI_PROJECT_ID --name=ocmlf-github-ci
+        make validate-terraform && \
+        echo -e "${CI_PROJECT_ID}\1\4" | make one-click-mlflow && \
+        make destroy && \
+        gcp projects delete $CI_PROJECT_ID


### PR DESCRIPTION
Hello all, here is a first draft of OCMLF's CI.
Give me your feedbacks on this.

### Issue

My PR resolves #27 

### Description

- add "make validate-terraform" to validate IaC without a backend
- people can give a project id instead of a numerical choice (to be able to specify the right project during the test)
- add a YAML file that will be used by Cloud Build

### To do manually to be able to test this

- Create a project that will manage ocmlf's CI
- Create a SA with roles/resourcemanager.projectCreator to be able to create a new project with this SA
- Give permissions to Cloud Build's SA to impersonate the created SA
- Create a Docker image with GCP SDK and Terraform and push it to GCP
- Create Cloud Build triggers for GitHub PRs on this project

### Questions

To finish the CI we'll need to do some steps manually (see previous section), but I could also make these steps with Terraform even if they'll need to be done only one time. What do you think is the best here?

