### PR TITLE
sqlparse 0.4.2 security update

### DIFF
--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -47,7 +47,7 @@ rsa==4.7.2
 six==1.16.0
 smmap==4.0.0
 SQLAlchemy==1.4.13
-sqlparse==0.4.1
+sqlparse==0.4.2
 tabulate==0.8.9
 typing-extensions==3.10.0.0
 urllib3==1.26.5


### PR DESCRIPTION
### Description

The formatter function that strips comments from a SQL contains a regular expression that is vulnerable to ReDoS (Regular Expression Denial of Service). The regular expression may cause exponential backtracking on strings containing many repetitions of '\r\n' in SQL comments.
The issues has been fixed in sqlparse 0.4.2.

### Licence

- [x] My PR adds the needed licence header to every added file:

### Commits

- [ ] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  2. Subject is limited to 50 characters
  3. Subject does not end with a period
  4. Subject uses the imperative mood ("add", not "adding")
  5. Body explains "what" and "why", not "how"
