### PR TITLE
fix: empty the gcp credentials env var to force the right token

### DIFF
--- a/examples/mlflow_config.py
+++ b/examples/mlflow_config.py
@@ -11,6 +11,7 @@ import requests
 
 
 def get_token():
+    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = ""
     if "mlflow-log-pusher-key.json" in os.listdir(Path(__file__).parent):
         os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = str(Path(__file__).parent / "mlflow-log-pusher-key.json")
     try:


### PR DESCRIPTION
### Issue

- [x] My PR addresses the following Issue: #75 

### Description

- [x] The ```GOOGLE_APPLICATION_CREDENTIALS``` will be emptied before getting a IAP token to force the user to use the right SA credentials in ```track_experiment.py```.

### Licence

- [x] My PR adds the needed licence header to every added file